### PR TITLE
Docsplat 850

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,7 @@ async function main() {
     repoInfo = await StagingUtils.getRepoInfo();
     user = StagingUtils.getGitUser(repoInfo);
   } catch (error) {
-    console.log("error ", error);
+    console.log('error ', error);
     return;
   }
 
@@ -78,6 +78,7 @@ async function main() {
   const branchName = upstreamConfig.split('/')[1];
   const url = `https://github.com/${repoOwner}/${repoName}`;
   repoName = repoName.replace('.git', '');
+  const visibility = await StagingUtils.checkIfPrivateRepo(url);
   // toggle btwn create patch from commits or what you have saved locally
   if (patchFlag === 'commit') {
     let firstCommit;
@@ -106,6 +107,7 @@ async function main() {
       buildSize,
       newHead,
       localBranch,
+      visibility,
     );
 
     try {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -77,6 +77,7 @@ module.exports = {
     buildSizeArg,
     lastCommit,
     localBranchArg,
+    visibility,
   ) {
     const payload = {
       jobType: 'githubPush',
@@ -87,7 +88,7 @@ module.exports = {
       upstream: upstreamConfig,
       localBranchName: localBranchArg,
       isFork: true,
-      private: false,
+      private: visibility,
       isXlarge: true,
       repoOwner: repoOwnerArg,
       url: urlArg,
@@ -211,12 +212,13 @@ module.exports = {
     }
   },
   async checkIfPrivateRepo(url) {
+    let cleanedURL = url.replace('.git', '');
+    cleanedURL = cleanedURL.replace(/\r?\n|\r/g, '');
     return new Promise((resolve, reject) => {
-      exec(`curl ${url} --head > visibility.txt`)
+      exec(`curl ${cleanedURL} --head > visibility.txt`)
         .then(() => {
           fs.readFile('visibility.txt', 'utf8', (err, data) => {
             if (err) {
-              console.log('error reading patch file: ', err);
               return reject(err);
             }
             if (data.includes('HTTP/1.1 200 OK')) {
@@ -225,10 +227,7 @@ module.exports = {
             return resolve(false);
           });
         })
-        .catch((error) => {
-          console.error('error generating patch: ', error);
-          return reject(error);
-        });
+        .catch((error) => reject(error));
     });
   },
 

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -210,6 +210,27 @@ module.exports = {
       throw error;
     }
   },
+  async checkIfPrivateRepo(url) {
+    return new Promise((resolve, reject) => {
+      exec(`curl ${url} --head > visibility.txt`)
+        .then(() => {
+          fs.readFile('visibility.txt', 'utf8', (err, data) => {
+            if (err) {
+              console.log('error reading patch file: ', err);
+              return reject(err);
+            }
+            if (data.includes('HTTP/1.1 200 OK')) {
+              return resolve(true);
+            }
+            return resolve(false);
+          });
+        })
+        .catch((error) => {
+          console.error('error generating patch: ', error);
+          return reject(error);
+        });
+    });
+  },
 
   async checkUpstreamConfiguration(localBranchName) {
     try {


### PR DESCRIPTION
previously, all jobs created with the script were hard coded to private: false. We curl the repo's url and look at the header to check if its public or not.