### PR TITLE
Dop 1329: Do Not Include Makefile in Patch

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,7 +145,7 @@ async function main() {
   //   } catch (error) {
   //     console.error(error);
   //   }
-  // }
+  }
 
   // await StagingUtils.deletePatchFile();
 }

--- a/app.js
+++ b/app.js
@@ -11,7 +11,16 @@ async function main() {
   let localBranch;
   const newHead = '';
 
-  await StagingUtils.checkForOnlyMakefileInDiff();
+  try {
+    const makefileOnly = await StagingUtils.checkForOnlyMakefileInDiff();
+    if (makefileOnly) {
+      const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
+      console.error(errormsg);
+      return;
+    }
+  } catch (error) {
+    return;
+  }
 
   // try {
   //   StagingUtils.validateConfiguration();

--- a/app.js
+++ b/app.js
@@ -14,7 +14,7 @@ async function main() {
   try {
     const makefileOnly = await StagingUtils.checkForOnlyMakefileInDiff(patchFlag);
     if (makefileOnly) {
-      const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
+      const errormsg = 'You have only made changes to the Makefile, which can\'t be staged. Please make changes to content files and then stage';
       console.error(errormsg);
       return;
     }

--- a/app.js
+++ b/app.js
@@ -104,17 +104,21 @@ async function main() {
       newHead,
       localBranch,
     );
-
-    try {
-      StagingUtils.insertJob(
-        payLoad,
-        `Github Push from Server Staging Scripts: ${user}/${repoName}`,
-        user,
-        userEmail,
-      );
-    } catch (error) {
-      console.error(error);
+    const makefileOnly = await StagingUtils.checkForMakefileInDiff()
+    if(makefileOnly == true){
+      console.log('trueeeee!')
+      return
     }
+    // try {
+    //   StagingUtils.insertJob(
+    //     payLoad,
+    //     `Github Push from Server Staging Scripts: ${user}/${repoName}`,
+    //     user,
+    //     userEmail,
+    //   );
+    // } catch (error) {
+    //   console.error(error);
+    // }
   }
 
   if (patchFlag === 'local') {
@@ -131,19 +135,19 @@ async function main() {
       localBranch,
     );
 
-    try {
-      await StagingUtils.insertJob(
-        payLoad,
-        `Github Push: ${user}/${repoName}`,
-        user,
-        userEmail,
-      );
-    } catch (error) {
-      console.error(error);
-    }
-  }
+  //   try {
+  //     await StagingUtils.insertJob(
+  //       payLoad,
+  //       `Github Push: ${user}/${repoName}`,
+  //       user,
+  //       userEmail,
+  //     );
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // }
 
-  await StagingUtils.deletePatchFile();
+  // await StagingUtils.deletePatchFile();
 }
 
 main();

--- a/app.js
+++ b/app.js
@@ -11,11 +11,8 @@ async function main() {
   let localBranch;
   const newHead = '';
 
-  const makefileOnly = await StagingUtils.checkForMakefileInDiff()
-  if(makefileOnly == true){
-    console.log('trueeeee!')
-    return
-  }
+  await StagingUtils.checkForOnlyMakefileInDiff();
+
   // try {
   //   StagingUtils.validateConfiguration();
   // } catch (error) {

--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ async function main() {
   const newHead = '';
 
   try {
-    const makefileOnly = await StagingUtils.checkForOnlyMakefileInDiff();
+    const makefileOnly = await StagingUtils.checkForOnlyMakefileInDiff(patchFlag);
     if (makefileOnly) {
       const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
       console.error(errormsg);

--- a/app.js
+++ b/app.js
@@ -11,129 +11,130 @@ async function main() {
   let localBranch;
   const newHead = '';
 
-  try {
-    StagingUtils.validateConfiguration();
-  } catch (error) {
-    return;
+  const makefileOnly = await StagingUtils.checkForMakefileInDiff()
+  if(makefileOnly == true){
+    console.log('trueeeee!')
+    return
   }
+  // try {
+  //   StagingUtils.validateConfiguration();
+  // } catch (error) {
+  //   return;
+  // }
 
-  if (patchFlag === undefined) {
-    console.log(
-      'You need a patch flag("commit" or "local") in your make command'
-    );
-    return;
-  }
+  // if (patchFlag === undefined) {
+  //   console.log(
+  //     'You need a patch flag("commit" or "local") in your make command'
+  //   );
+  //   return;
+  // }
 
-  let invalidFlag = false;
+  // let invalidFlag = false;
 
-  if (patchFlag !== 'local' && patchFlag !== 'commit') {
-    console.log(
-      'Invalid patch flag. Use "commit" to stage a build from the committed work you have locally or use "local" to stage a build from the uncommitted work you have locally'
-    );
-    invalidFlag = true;
-  }
+  // if (patchFlag !== 'local' && patchFlag !== 'commit') {
+  //   console.log(
+  //     'Invalid patch flag. Use "commit" to stage a build from the committed work you have locally or use "local" to stage a build from the uncommitted work you have locally'
+  //   );
+  //   invalidFlag = true;
+  // }
 
-  if (invalidFlag === true) {
-    return;
-  }
+  // if (invalidFlag === true) {
+  //   return;
+  // }
 
-  try {
-    userEmail = await StagingUtils.getGitEmail();
-  } catch (error) {
-    return;
-  }
+  // try {
+  //   userEmail = await StagingUtils.getGitEmail();
+  // } catch (error) {
+  //   return;
+  // }
 
-  try {
-    localBranch = await StagingUtils.getBranchName();
-  } catch (error) {
-    console.error(error);
-    return;
-  }
-  let repoInfo;
+  // try {
+  //   localBranch = await StagingUtils.getBranchName();
+  // } catch (error) {
+  //   console.error(error);
+  //   return;
+  // }
+  // let repoInfo;
 
-  try {
-    upstreamConfig = await StagingUtils.checkUpstreamConfiguration(localBranch);
-    upstreamConfig = upstreamConfig.replace(/\r?\n|\r/g, "");
-  } catch (error) {
-    console.error(error);
-    return;
-  }
+  // try {
+  //   upstreamConfig = await StagingUtils.checkUpstreamConfiguration(localBranch);
+  //   upstreamConfig = upstreamConfig.replace(/\r?\n|\r/g, "");
+  // } catch (error) {
+  //   console.error(error);
+  //   return;
+  // }
 
-  try {
-    upstreamOwnerAndName = await StagingUtils.getUpstreamRepo();
-  } catch (error) {
-    console.error(error);
-    return;
-  }
+  // try {
+  //   upstreamOwnerAndName = await StagingUtils.getUpstreamRepo();
+  // } catch (error) {
+  //   console.error(error);
+  //   return;
+  // }
 
-  try {
-    repoInfo = await StagingUtils.getRepoInfo();
-    user = StagingUtils.getGitUser(repoInfo);
-  } catch (error) {
-    console.log("error ", error);
-    return;
-  }
+  // try {
+  //   repoInfo = await StagingUtils.getRepoInfo();
+  //   user = StagingUtils.getGitUser(repoInfo);
+  // } catch (error) {
+  //   console.log("error ", error);
+  //   return;
+  // }
 
-  let [repoOwner, repoName] = upstreamOwnerAndName.split('/');
-  const branchName = upstreamConfig.split('/')[1];
-  const url = `https://github.com/${repoOwner}/${repoName}`;
-  repoName = repoName.replace('.git', '');
-  // toggle btwn create patch from commits or what you have saved locally
-  if (patchFlag === 'commit') {
-    let firstCommit;
-    let lastCommit;
+  // let [repoOwner, repoName] = upstreamOwnerAndName.split('/');
+  // const branchName = upstreamConfig.split('/')[1];
+  // const url = `https://github.com/${repoOwner}/${repoName}`;
+  // repoName = repoName.replace('.git', '');
+  // // toggle btwn create patch from commits or what you have saved locally
+  // if (patchFlag === 'commit') {
+  //   let firstCommit;
+  //   let lastCommit;
 
-    // make sure they have made at least one commit
-    try {
-      await StagingUtils.getGitCommits();
-    } catch (error) {
-      console.error(error);
-      return;
-    }
+  //   // make sure they have made at least one commit
+  //   try {
+  //     await StagingUtils.getGitCommits();
+  //   } catch (error) {
+  //     console.error(error);
+  //     return;
+  //   }
 
-    const patch = await StagingUtils.getGitPatchFromCommits();
+  //   const patch = await StagingUtils.getGitPatchFromCommits();
 
-    const payLoad = StagingUtils.createPayload(
-      repoName,
-      branchName,
-      upstreamConfig,
-      repoOwner,
-      url,
-      patch,
-      buildSize,
-      newHead,
-      localBranch,
-    );
-    const makefileOnly = await StagingUtils.checkForMakefileInDiff()
-    if(makefileOnly == true){
-      console.log('trueeeee!')
-      return
-    }
-    // try {
-    //   StagingUtils.insertJob(
-    //     payLoad,
-    //     `Github Push from Server Staging Scripts: ${user}/${repoName}`,
-    //     user,
-    //     userEmail,
-    //   );
-    // } catch (error) {
-    //   console.error(error);
-    // }
-  }
+  //   const payLoad = StagingUtils.createPayload(
+  //     repoName,
+  //     branchName,
+  //     upstreamConfig,
+  //     repoOwner,
+  //     url,
+  //     patch,
+  //     buildSize,
+  //     newHead,
+  //     localBranch,
+  //   );
 
-  if (patchFlag === 'local') {
-    const patch = await StagingUtils.getGitPatchFromLocal(upstreamConfig);
-    const payLoad = StagingUtils.createPayload(
-      repoName,
-      branchName,
-      upstreamConfig,
-      repoOwner,
-      url,
-      patch,
-      buildSize,
-      newHead,
-      localBranch,
-    );
+  //   try {
+  //     StagingUtils.insertJob(
+  //       payLoad,
+  //       `Github Push from Server Staging Scripts: ${user}/${repoName}`,
+  //       user,
+  //       userEmail,
+  //     );
+  //   } catch (error) {
+  //     console.error(error);
+  //   }
+  // }
+
+  // if (patchFlag === 'local') {
+  //   const patch = await StagingUtils.getGitPatchFromLocal(upstreamConfig);
+  //   const payLoad = StagingUtils.createPayload(
+  //     repoName,
+  //     branchName,
+  //     upstreamConfig,
+  //     repoOwner,
+  //     url,
+  //     patch,
+  //     buildSize,
+  //     newHead,
+  //     localBranch,
+  //   );
 
   //   try {
   //     await StagingUtils.insertJob(
@@ -145,7 +146,7 @@ async function main() {
   //   } catch (error) {
   //     console.error(error);
   //   }
-  }
+  // }
 
   // await StagingUtils.deletePatchFile();
 }

--- a/app.js
+++ b/app.js
@@ -22,139 +22,139 @@ async function main() {
     return;
   }
 
-  // try {
-  //   StagingUtils.validateConfiguration();
-  // } catch (error) {
-  //   return;
-  // }
+  try {
+    StagingUtils.validateConfiguration();
+  } catch (error) {
+    return;
+  }
 
-  // if (patchFlag === undefined) {
-  //   console.log(
-  //     'You need a patch flag("commit" or "local") in your make command'
-  //   );
-  //   return;
-  // }
+  if (patchFlag === undefined) {
+    console.log(
+      'You need a patch flag("commit" or "local") in your make command'
+    );
+    return;
+  }
 
-  // let invalidFlag = false;
+  let invalidFlag = false;
 
-  // if (patchFlag !== 'local' && patchFlag !== 'commit') {
-  //   console.log(
-  //     'Invalid patch flag. Use "commit" to stage a build from the committed work you have locally or use "local" to stage a build from the uncommitted work you have locally'
-  //   );
-  //   invalidFlag = true;
-  // }
+  if (patchFlag !== 'local' && patchFlag !== 'commit') {
+    console.log(
+      'Invalid patch flag. Use "commit" to stage a build from the committed work you have locally or use "local" to stage a build from the uncommitted work you have locally'
+    );
+    invalidFlag = true;
+  }
 
-  // if (invalidFlag === true) {
-  //   return;
-  // }
+  if (invalidFlag === true) {
+    return;
+  }
 
-  // try {
-  //   userEmail = await StagingUtils.getGitEmail();
-  // } catch (error) {
-  //   return;
-  // }
+  try {
+    userEmail = await StagingUtils.getGitEmail();
+  } catch (error) {
+    return;
+  }
 
-  // try {
-  //   localBranch = await StagingUtils.getBranchName();
-  // } catch (error) {
-  //   console.error(error);
-  //   return;
-  // }
-  // let repoInfo;
+  try {
+    localBranch = await StagingUtils.getBranchName();
+  } catch (error) {
+    console.error(error);
+    return;
+  }
+  let repoInfo;
 
-  // try {
-  //   upstreamConfig = await StagingUtils.checkUpstreamConfiguration(localBranch);
-  //   upstreamConfig = upstreamConfig.replace(/\r?\n|\r/g, "");
-  // } catch (error) {
-  //   console.error(error);
-  //   return;
-  // }
+  try {
+    upstreamConfig = await StagingUtils.checkUpstreamConfiguration(localBranch);
+    upstreamConfig = upstreamConfig.replace(/\r?\n|\r/g, "");
+  } catch (error) {
+    console.error(error);
+    return;
+  }
 
-  // try {
-  //   upstreamOwnerAndName = await StagingUtils.getUpstreamRepo();
-  // } catch (error) {
-  //   console.error(error);
-  //   return;
-  // }
+  try {
+    upstreamOwnerAndName = await StagingUtils.getUpstreamRepo();
+  } catch (error) {
+    console.error(error);
+    return;
+  }
 
-  // try {
-  //   repoInfo = await StagingUtils.getRepoInfo();
-  //   user = StagingUtils.getGitUser(repoInfo);
-  // } catch (error) {
-  //   console.log("error ", error);
-  //   return;
-  // }
+  try {
+    repoInfo = await StagingUtils.getRepoInfo();
+    user = StagingUtils.getGitUser(repoInfo);
+  } catch (error) {
+    console.log("error ", error);
+    return;
+  }
 
-  // let [repoOwner, repoName] = upstreamOwnerAndName.split('/');
-  // const branchName = upstreamConfig.split('/')[1];
-  // const url = `https://github.com/${repoOwner}/${repoName}`;
-  // repoName = repoName.replace('.git', '');
-  // // toggle btwn create patch from commits or what you have saved locally
-  // if (patchFlag === 'commit') {
-  //   let firstCommit;
-  //   let lastCommit;
+  let [repoOwner, repoName] = upstreamOwnerAndName.split('/');
+  const branchName = upstreamConfig.split('/')[1];
+  const url = `https://github.com/${repoOwner}/${repoName}`;
+  repoName = repoName.replace('.git', '');
+  // toggle btwn create patch from commits or what you have saved locally
+  if (patchFlag === 'commit') {
+    let firstCommit;
+    let lastCommit;
 
-  //   // make sure they have made at least one commit
-  //   try {
-  //     await StagingUtils.getGitCommits();
-  //   } catch (error) {
-  //     console.error(error);
-  //     return;
-  //   }
+    // make sure they have made at least one commit
+    try {
+      await StagingUtils.getGitCommits();
+    } catch (error) {
+      console.error(error);
+      return;
+    }
 
-  //   const patch = await StagingUtils.getGitPatchFromCommits();
+    const patch = await StagingUtils.getGitPatchFromCommits();
 
-  //   const payLoad = StagingUtils.createPayload(
-  //     repoName,
-  //     branchName,
-  //     upstreamConfig,
-  //     repoOwner,
-  //     url,
-  //     patch,
-  //     buildSize,
-  //     newHead,
-  //     localBranch,
-  //   );
+    const payLoad = StagingUtils.createPayload(
+      repoName,
+      branchName,
+      upstreamConfig,
+      repoOwner,
+      url,
+      patch,
+      buildSize,
+      newHead,
+      localBranch,
+    );
 
-  //   try {
-  //     StagingUtils.insertJob(
-  //       payLoad,
-  //       `Github Push from Server Staging Scripts: ${user}/${repoName}`,
-  //       user,
-  //       userEmail,
-  //     );
-  //   } catch (error) {
-  //     console.error(error);
-  //   }
-  // }
+    try {
+      StagingUtils.insertJob(
+        payLoad,
+        `Github Push from Server Staging Scripts: ${user}/${repoName}`,
+        user,
+        userEmail,
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
-  // if (patchFlag === 'local') {
-  //   const patch = await StagingUtils.getGitPatchFromLocal(upstreamConfig);
-  //   const payLoad = StagingUtils.createPayload(
-  //     repoName,
-  //     branchName,
-  //     upstreamConfig,
-  //     repoOwner,
-  //     url,
-  //     patch,
-  //     buildSize,
-  //     newHead,
-  //     localBranch,
-  //   );
+  if (patchFlag === 'local') {
+    const patch = await StagingUtils.getGitPatchFromLocal(upstreamConfig);
+    const payLoad = StagingUtils.createPayload(
+      repoName,
+      branchName,
+      upstreamConfig,
+      repoOwner,
+      url,
+      patch,
+      buildSize,
+      newHead,
+      localBranch,
+    );
 
-  //   try {
-  //     await StagingUtils.insertJob(
-  //       payLoad,
-  //       `Github Push: ${user}/${repoName}`,
-  //       user,
-  //       userEmail,
-  //     );
-  //   } catch (error) {
-  //     console.error(error);
-  //   }
-  // }
+    try {
+      await StagingUtils.insertJob(
+        payLoad,
+        `Github Push: ${user}/${repoName}`,
+        user,
+        userEmail,
+      );
+    } catch (error) {
+      console.error(error);
+    }
+  }
 
-  // await StagingUtils.deletePatchFile();
+  await StagingUtils.deletePatchFile();
 }
 
 main();

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -245,13 +245,12 @@ module.exports = {
     try {
       const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
 
-      //the patch would consist only of Makefile diff
       if (changedFiles === 'Makefile') {
-        return true;
+        const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
+        console.error(errormsg);
+        throw errormsg;
       }
-      const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
-      console.error(errormsg);
-      throw errormsg;
+
     } catch (error) {
       console.error(error);
       throw error;

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -260,21 +260,21 @@ module.exports = {
 
   async getGitPatchFromCommits() {
     return new Promise((resolve, reject) => {
-        const patchCommand = `git diff master...HEAD --ignore-submodules ':(exclude)Makefile' > myPatch.patch`;
-        exec(patchCommand)
-          .then(() => {
-            fs.readFile('myPatch.patch', 'utf8', (err, data) => {
-              if (err) {
-                console.error('error reading patch file: ', err);
-                reject(err);
-              }
-              resolve(data);
-            });
-          })
-          .catch((error) => {
-            console.error('error generating patch: ', error);
-            reject(error);
+      const patchCommand = `git diff master...HEAD --ignore-submodules ':(exclude)Makefile' > myPatch.patch`;
+      exec(patchCommand)
+        .then(() => {
+          fs.readFile('myPatch.patch', 'utf8', (err, data) => {
+            if (err) {
+              console.error('error reading patch file: ', err);
+              reject(err);
+            }
+            resolve(data);
           });
+        })
+        .catch((error) => {
+          console.error('error generating patch: ', error);
+          reject(error);
+        });
     });
   },
 

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -224,7 +224,7 @@ module.exports = {
 
   async getGitPatchFromLocal(upstreamBranchName) {
     return new Promise((resolve, reject) => {
-      exec(`git diff ${upstreamBranchName} --ignore-submodules > myPatch.patch`)
+      exec(`git diff ${upstreamBranchName} --ignore-submodules ':(exclude)Makefile'> myPatch.patch`)
         .then(() => {
           fs.readFile('myPatch.patch', 'utf8', (err, data) => {
             if (err) {
@@ -242,7 +242,7 @@ module.exports = {
   },
   async getGitPatchFromCommits() {
     return new Promise((resolve, reject) => {
-        const patchCommand = `git diff master...HEAD --ignore-submodules > myPatch.patch`;
+        const patchCommand = `git diff master...HEAD ':(exclude)Makefile' --ignore-submodules > myPatch.patch`;
         exec(patchCommand)
           .then(() => {
             fs.readFile('myPatch.patch', 'utf8', (err, data) => {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -241,16 +241,17 @@ module.exports = {
     });
   },
 
-  async checkForMakefileInDiff() {
+  async checkForOnlyMakefileInDiff() {
     try {
       const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
-      console.log("these are the changed files: ", changedFiles);
-      // patch would consist only of Makefile diff
+
+      //the patch would consist only of Makefile diff
       if (changedFiles === 'Makefile') {
-        console.log("true!!!")
         return true;
       }
-      return false;
+      const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
+      console.error(errormsg);
+      throw errormsg;
     } catch (error) {
       console.error(error);
       throw error;

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -242,7 +242,7 @@ module.exports = {
   },
   async getGitPatchFromCommits() {
     return new Promise((resolve, reject) => {
-        const patchCommand = `git diff master...HEAD ':(exclude)Makefile' --ignore-submodules > myPatch.patch`;
+        const patchCommand = `git diff master...HEAD --ignore-submodules ':(exclude)Makefile' > myPatch.patch`;
         exec(patchCommand)
           .then(() => {
             fs.readFile('myPatch.patch', 'utf8', (err, data) => {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -242,19 +242,21 @@ module.exports = {
   },
 
   async checkForOnlyMakefileInDiff() {
-    try {
-      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
-
-      if (changedFiles === 'Makefile') {
-        const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
-        console.error(errormsg);
-        throw errormsg;
-      }
-
-    } catch (error) {
-      console.error(error);
-      throw error;
-    }
+    return new Promise((resolve, reject) => {
+      const patchCommand = 'git diff --name-only --ignore-submodules';
+      exec(patchCommand)
+        .then((changedFiles) => {
+          if (changedFiles === 'Makefile') {
+            const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
+            console.error(errormsg);
+            reject(errormsg);
+          }
+        })
+        .catch((error) => {
+          console.error('error generating patch: ', error);
+          reject(error);
+        });
+    });
   },
 
   async getGitPatchFromCommits() {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -243,9 +243,10 @@ module.exports = {
 
   async checkForOnlyMakefileInDiff() {
     return new Promise((resolve, reject) => {
-      const patchCommand = 'git diff --name-only --ignore-submodules';
-      exec(patchCommand)
-        .then((changedFiles) => {
+      const command = 'git diff --name-only --ignore-submodules';
+      exec(command)
+        .then((result) => {
+          const changedFiles = result.stdout.trim();
           if (changedFiles === 'Makefile') {
             const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
             console.error(errormsg);

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -244,7 +244,6 @@ module.exports = {
   async checkForOnlyMakefileInDiff() {
     try {
       const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
-
       if (changedFiles === 'Makefile') {
         return true;
       }

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -243,7 +243,7 @@ module.exports = {
 
   async checkForMakefileInDiff() {
     try {
-      const changedFiles = (await exec(`git diff --name-only --ignore-submodules ':(exclude)Makefile'`)).stdout;
+      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout;
       console.log("these are the changed files: ", changedFiles);
       // patch would consist only of Makefile diff
       if (changedFiles === 'Makefile') {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -243,27 +243,12 @@ module.exports = {
 
   async checkForMakefileInDiff() {
     try {
-      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout;
+      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
       console.log("these are the changed files: ", changedFiles);
       // patch would consist only of Makefile diff
       if (changedFiles === 'Makefile') {
         console.log("true!!!")
         return true;
-      }
-      var i = 0;
-      var j = 0;
-      var result = "";
-  
-      while (j < changedFiles.length)
-      {
-        if ('Makefile'[i] !== changedFiles[j] || i === 'Makefile'.length) {
-          result += changedFiles[j];
-          console.log(changedFiles[j]);
-        }
-        else {
-          i++;
-        }
-        j++;
       }
       return false;
     } catch (error) {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -241,9 +241,15 @@ module.exports = {
     });
   },
 
-  async checkForOnlyMakefileInDiff() {
+  async checkForOnlyMakefileInDiff(patchType) {
     try {
-      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
+      let command;
+      if (patchType === 'commit') {
+        command = 'git diff master...HEAD --name-only --ignore-submodules';
+      } else {
+        command = 'git diff --name-only --ignore-submodules';
+      }
+      const changedFiles = (await exec(command)).stdout.trim();
       if (changedFiles === 'Makefile') {
         return true;
       }

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -247,7 +247,23 @@ module.exports = {
       console.log("these are the changed files: ", changedFiles);
       // patch would consist only of Makefile diff
       if (changedFiles === 'Makefile') {
+        console.log("true!!!")
         return true;
+      }
+      var i = 0;
+      var j = 0;
+      var result = "";
+  
+      while (j < changedFiles.length)
+      {
+        if ('Makefile'[i] !== changedFiles[j] || i === 'Makefile'.length) {
+          result += changedFiles[j];
+          console.log(changedFiles[j]);
+        }
+        else {
+          i++;
+        }
+        j++;
       }
       return false;
     } catch (error) {

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -240,21 +240,22 @@ module.exports = {
         });
     });
   },
-  async checkForMakefileInDiff(){
 
-      try {
-        const changedFiles = (await exec(`git diff --name-only --ignore-submodules ':(exclude)Makefile'`)).stdout;
-        console.log("these are the changed files: ", changedFiles)
-        // patch would consist only of Makefile diff
-        if(changedFiles === 'Makefile'){
-          return true
-        }
-        return false;
-      } catch (error) {
-        console.error(error);
-        throw error;
+  async checkForMakefileInDiff() {
+    try {
+      const changedFiles = (await exec(`git diff --name-only --ignore-submodules ':(exclude)Makefile'`)).stdout;
+      console.log("these are the changed files: ", changedFiles);
+      // patch would consist only of Makefile diff
+      if (changedFiles === 'Makefile') {
+        return true;
       }
-  }
+      return false;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  },
+
   async getGitPatchFromCommits() {
     return new Promise((resolve, reject) => {
         const patchCommand = `git diff master...HEAD --ignore-submodules ':(exclude)Makefile' > myPatch.patch`;

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -240,6 +240,21 @@ module.exports = {
         });
     });
   },
+  async checkForMakefileInDiff(){
+
+      try {
+        const changedFiles = (await exec(`git diff --name-only --ignore-submodules ':(exclude)Makefile'`)).stdout;
+        console.log("these are the changed files: ", changedFiles)
+        // patch would consist only of Makefile diff
+        if(changedFiles === 'Makefile'){
+          return true
+        }
+        return false;
+      } catch (error) {
+        console.error(error);
+        throw error;
+      }
+  }
   async getGitPatchFromCommits() {
     return new Promise((resolve, reject) => {
         const patchCommand = `git diff master...HEAD --ignore-submodules ':(exclude)Makefile' > myPatch.patch`;

--- a/stagingUtils.js
+++ b/stagingUtils.js
@@ -242,22 +242,17 @@ module.exports = {
   },
 
   async checkForOnlyMakefileInDiff() {
-    return new Promise((resolve, reject) => {
-      const command = 'git diff --name-only --ignore-submodules';
-      exec(command)
-        .then((result) => {
-          const changedFiles = result.stdout.trim();
-          if (changedFiles === 'Makefile') {
-            const errormsg = 'You have only made changes to the Makefile, which is not staged. Please make changes to content files and then stage';
-            console.error(errormsg);
-            reject(errormsg);
-          }
-        })
-        .catch((error) => {
-          console.error('error generating patch: ', error);
-          reject(error);
-        });
-    });
+    try {
+      const changedFiles = (await exec('git diff --name-only --ignore-submodules')).stdout.trim();
+
+      if (changedFiles === 'Makefile') {
+        return true;
+      }
+      return false;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   },
 
   async getGitPatchFromCommits() {


### PR DESCRIPTION
This PR will allow us to first check the differing files to make sure the user is not trying to just stage makefile changes. It logs an error to the user and exits if that is the case. 

If the user is staging content files, the patch explicitly excludes the Makefile to make sure that doesn't get pushed up. 